### PR TITLE
Generalize template pluralization branches

### DIFF
--- a/templates/display.html
+++ b/templates/display.html
@@ -6,17 +6,11 @@
   {% if search %}
     {% if posts.count == 0 %}
       <h4>There are no Syllabi matching your search at the {{school}} sorry! <br>Try to add them!</h4>
-    {% elif posts.count == 1 %}
-      <h4>There is 1 Syllabus matching your search at the {{school}}!</h4>
     {% else %}
-      <h4>There are {{posts.count}} Syllabi matching your search at the {{school}}!</h4>
+      <h4>There {{posts.count|pluralize:"is,are"}} {{posts.count}} Syllab{{posts.count|pluralize:"us,i"}} matching your search at the {{school}}!</h4>
     {% endif %}
-  {% else %}  
-    {% if posts.count == 1 %}
-      <h4>There is 1 Syllabus for {{dept}} courses! Add More!</h4>
-    {% else %}
-      <h4>There are {{posts.count}} Syllabi for {{dept}} courses! Add More!</h4>
-    {% endif %}
+  {% else %}
+    <h4>There {{posts.count|pluralize:"is,are"}} {{posts.count}} Syllab{{posts.count|pluralize:"us,i"}} for {{dept}} courses! Add More!</h4>
   {% endif %}<br>
 
   {% for post in posts %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,11 +2,7 @@
 {% load static %}
 {% block content %}
 
-{% if num == 1 %}
-<h4 class="text-center">There is 1 Syllabus for the {{school}}! Add More!</h4>
-{% else %}
-<h4 class="text-center">There are {{num}} Syllabi for the {{school}}! Add More!</h4>
-{% endif %}
+<h4 class="text-center">There {{num|pluralize:"is,are"}} {{num}} Syllab{{num|pluralize:"us,i"}} for the {{school}}! Add More!</h4>
 
 <div style="width: 60%; margin: auto;" class="text-center">
   {% for dept in posts %}


### PR DESCRIPTION
[`pluralize`](https://docs.djangoproject.com/en/2.2/ref/templates/builtins/#pluralize) is pretty neat :)

Also, I was looking this up for unrelated reasons yesterday, and you might want to see if `posts|length` works instead of `posts.count`? The former should be more efficient, but I wasn't able to get it working for Satori.