### PR TITLE
gitignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ staticfiles/
 .vscode/
 .idea/
 project/uploads
+
+venv/


### PR DESCRIPTION
Didn't see any other venv-specific folders in the gitignore, so here we go?