### PR TITLE
Responsive navbar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
   </head>
 
   <body style="background-image: url({% static 'back.png' %}); background-size: cover;">
-    <nav class="navbar navbar-expand-lg bg-dark navbar-dark">
+    <nav class="navbar navbar-expand-md bg-dark navbar-dark">
       <a class="navbar-brand" href="/">SyllabiShare</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 {% load static %}
-<!doctype html> 
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -15,42 +15,46 @@
   <body style="background-image: url({% static 'back.png' %}); background-size: cover;">
     <nav class="navbar navbar-expand-lg bg-dark navbar-dark">
       <a class="navbar-brand" href="/">SyllabiShare</a>
-      <ul class="navbar-nav mr-auto">
-      </ul>
-      <ul class="navbar-nav navbar-right">
-        <li class="nav-item" style="padding-top:1%">
-          <form action="/search/" method="POST">
-            {% csrf_token %}
-            <input style="width:50%;" id="search" type="text" name="search">
-            <input class="btn-success" id='button' type="submit" value="Search">
-          </form>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="/upload">upload</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="/suggest">feedback</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="/about">about</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbardrop" data-toggle="dropdown">
-          {{user.username}}
-          </a>
-          <div class="dropdown-menu dropdown-menu-right" style="text-align: right; min-width: 0;">
-            <a class="dropdown-item" href="{% url 'logout' %}"> Logout </a> 
-            <a class="dropdown-item" href="/settings">Settings</a>
-          </div>
-        </li>
-      </ul>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-item" style="padding-top:1%">
+            <form action="/search/" method="POST">
+              {% csrf_token %}
+              <input style="width:50%;" id="search" type="text" name="search">
+              <input class="btn-success" id='button' type="submit" value="Search">
+            </form>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/upload">upload</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/suggest">feedback</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/about">about</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbardrop" data-toggle="dropdown">
+            {{user.username}}
+            </a>
+            <div class="dropdown-menu dropdown-menu-right" style="text-align: right; min-width: 0;">
+              <a class="dropdown-item" href="{% url 'logout' %}"> Logout </a>
+              <a class="dropdown-item" href="/settings">Settings</a>
+            </div>
+          </li>
+        </ul>
+      </div>
     </nav>
 
     <div style="padding: 2%">
       {% block content %}
       {% endblock %}
     </div>
-    
+
     <a href="https://github.com/verndrade/syllabi-share"><img class="github" src="{% static 'github.png' %}"></a>
   </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,8 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"></script>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
 
   <body style="background-image: url({% static 'back.png' %}); background-size: cover;">


### PR DESCRIPTION
**View diff without whitespace:** https://github.com/SyllabiShare/syllabi-share/pull/45/files?w=1

Made the whole app scale responsively (not actually _be_ responsive) along the way with the viewport meta tag in order to properly test my changes.

Of course, that opens up a whole new can of worms (the overlapping leaderboard is much more noticeable now on mobile), but it's a start.

Tablet:
![tablet](https://user-images.githubusercontent.com/2766036/82857343-b7b14d80-9ede-11ea-9c81-ff1f0d0da869.png)

Phone:
![phone](https://user-images.githubusercontent.com/2766036/82857362-c4ce3c80-9ede-11ea-8525-f541f9d70499.png)