### PR TITLE
View own uploaded syllabi

### DIFF
--- a/project/static/style.css
+++ b/project/static/style.css
@@ -165,9 +165,17 @@ body {
 }
 
 .syllabus {
-    display: inline-block;
+    width: 20rem;
+    padding: 1rem;
 }
 
 .syllabus li {
     list-style: none;
+}
+
+/* when the screen is small enough for one syllabus per line */
+@media only screen and (max-width: 55rem) {
+    .syllabus {
+        width: 100%;
+    }
 }

--- a/project/static/style.css
+++ b/project/static/style.css
@@ -181,13 +181,6 @@ it's unfortunate that this isn't an official component */
     max-width: 100%;
 }
 
-/* when the screen is small enough for one syllabus per line */
-@media only screen and (max-width: 55rem) {
-    .card {
-        width: 100%;
-    }
-}
-
 /* for easy ref, Bootstrap's breakpoints
  * sm - min-width: 576px
  * md - min-width: 768px

--- a/project/static/style.css
+++ b/project/static/style.css
@@ -153,6 +153,30 @@ body {
     background-color: var(--danger);
 }
 
+
+/* overwriting card styles for syllabus info */
+.card, .card-title, .list-group-item {
+    background-color: transparent;
+    border: none;
+}
+
+.card {
+    width: 20rem;
+    margin: 0.25rem;
+    padding-bottom: 0.5rem;
+    background-color: rgba(255,255,255,0.25);
+}
+
+.card-title {
+    font-weight: bold;
+}
+
+.list-group-item {
+    padding-top: 0;
+    padding-bottom: 0.1rem;
+}
+
+
 /* These form widths are arbitrary, but they look nice ¯\_(ツ)_/¯ */
 .signup-form {
     width: 600px;
@@ -164,18 +188,9 @@ body {
     max-width: 100%;
 }
 
-.syllabus {
-    width: 20rem;
-    padding: 1rem;
-}
-
-.syllabus li {
-    list-style: none;
-}
-
 /* when the screen is small enough for one syllabus per line */
 @media only screen and (max-width: 55rem) {
-    .syllabus {
+    .card {
         width: 100%;
     }
 }

--- a/project/static/style.css
+++ b/project/static/style.css
@@ -159,29 +159,6 @@ body {
     background-color: var(--danger);
 }
 
-
-/* overwriting card styles for syllabus info */
-.card, .card-title, .list-group-item {
-    background-color: transparent;
-    border: none;
-}
-
-.card {
-    width: 20rem;
-    margin: 0.25rem;
-    padding-bottom: 0.5rem;
-    background-color: rgba(255,255,255,0.25);
-}
-
-.card-title {
-    font-weight: bold;
-}
-
-.list-group-item {
-    padding-top: 0;
-    padding-bottom: 0.1rem;
-}
-
 /* Approximate reconstruction from the CSS from the Bootstrap docs,
 it's unfortunate that this isn't an official component */
 .callout {

--- a/project/static/style.css
+++ b/project/static/style.css
@@ -163,3 +163,11 @@ body {
     width: 400px;
     max-width: 100%;
 }
+
+.syllabus {
+    display: inline-block;
+}
+
+.syllabus li {
+    list-style: none;
+}

--- a/project/static/style.css
+++ b/project/static/style.css
@@ -176,6 +176,14 @@ body {
     padding-bottom: 0.1rem;
 }
 
+.callout {
+    padding: 0.5rem 1rem;
+    margin: 1rem 0;
+}
+
+.callout-warning {
+    border-left: 0.25rem solid var(--yellow);
+}
 
 /* These form widths are arbitrary, but they look nice ¯\_(ツ)_/¯ */
 .signup-form {

--- a/project/static/style.css
+++ b/project/static/style.css
@@ -182,6 +182,8 @@ body {
     padding-bottom: 0.1rem;
 }
 
+/* Approximate reconstruction from the CSS from the Bootstrap docs,
+it's unfortunate that this isn't an official component */
 .callout {
     padding: 0.5rem 1rem;
     margin: 1rem 0;

--- a/syllabiShare/urls.py
+++ b/syllabiShare/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('takedown', views.takedown, name="takedown"),
     path('about/', views.about, name="about"),
     path(settings.ADMIN_URL, views.admin, name="admin"),
+    path('myuploads/', views.myuploads, name="myuploads"),
     path('privacy/', views.privacy, name="privacy"),
     path('search/', views.search, name="search"),
     path('settings/', views.setting, name="setting"),

--- a/syllabiShare/views.py
+++ b/syllabiShare/views.py
@@ -220,11 +220,11 @@ def takedown(request):
 @login_required
 @user_passes_test(takedown_check, login_url='syllabiShare:takedown', redirect_field_name=None)
 def myuploads(request):
-    posts = Submission.objects.filter(school=request.user.profile.school).filter(user=request.user).order_by('number').order_by('dept')
+    posts = Submission.objects.filter(school=request.user.profile.school).filter(user=request.user).order_by('dept', 'number')
     if len(posts) == 0:
         messages.error(request, 'You have not uploaded any syllabi yet.')
         return redirect('syllabiShare:upload') # nothing to show before uploading something!
-    return render(request, 'myuploads.html', {'posts': posts, 'AWS_S3_CUSTOM_DOMAIN':settings.AWS_S3_CUSTOM_DOMAIN, 'school': request.user.profile.school.name})
+    return render(request, 'myuploads.html', {'posts': posts, 'AWS_S3_CUSTOM_DOMAIN':settings.AWS_S3_CUSTOM_DOMAIN, 'school': request.user.profile.school.name, 'breadcrumb': 'Your Uploads'})
 
 
 def privacy(request):

--- a/syllabiShare/views.py
+++ b/syllabiShare/views.py
@@ -217,6 +217,16 @@ def takedown(request):
     return redirect('syllabiShare:index')
 
 
+@login_required
+@user_passes_test(takedown_check, login_url='syllabiShare:takedown', redirect_field_name=None)
+def myuploads(request):
+    posts = Submission.objects.filter(school=request.user.profile.school).filter(user=request.user).order_by('number').order_by('dept')
+    if len(posts) == 0:
+        messages.error(request, 'You have not uploaded any syllabi yet.')
+        return redirect('syllabiShare:upload') # nothing to show before uploading something!
+    return render(request, 'myuploads.html', {'posts': posts, 'AWS_S3_CUSTOM_DOMAIN':settings.AWS_S3_CUSTOM_DOMAIN, 'school': request.user.profile.school.name})
+
+
 def privacy(request):
     return render(request, 'privacy.html', {'breadcrumb': 'Privacy Policy'})
 

--- a/templates/myuploads.html
+++ b/templates/myuploads.html
@@ -10,20 +10,24 @@
   <p class="mb-0">Please email <a href="mailto:syllabishare@gmail.com?subject=Error%20in%20syllabus">syllabishare@gmail.com</a> or <a href='https://github.com/SyllabiShare/syllabi-share/issues'>open an issue on GitHub</a>.</p>
 </div>
 
-<div class="d-flex flex-wrap">
+<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3">
   {% for post in posts %}
-  <div class="card bg-light">
-      <h5 class="card-title card-header"><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" target="_blank">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</a></h5>
-      <ul class="list-group list-group-flush">
-        <li class="list-group-item"><strong>Course title:</strong> {{post.title}}</li>
-        <li class="list-group-item"><strong>Semester:</strong> {{post.semester|capfirst}} {{post.year}}</li>
-        <li class="list-group-item">
-            <strong>Approved and visible?</strong>
-            {% if post.hidden %} No
-            {% else %} Yes
-            {% endif %}
+  <div class="d-flex col">
+    <div class="card my-3 flex-fill">
+      <div class="card-body bg-light">
+        <h5 class="card-title mb-0"><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" target="_blank">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</a></h5>
+      </div>
+      <ul class="list-unstyled pl-4 mt-2">
+        <li><strong>Course title:</strong> {{post.title}}</li>
+        <li><strong>Semester:</strong> {{post.semester|capfirst}} {{post.year}}</li>
+        <li>
+          <strong>Approved and visible?</strong>
+          {% if post.hidden %} No
+          {% else %} Yes
+          {% endif %}
         </li>
       </ul>
+    </div>
   </div>
   {% endfor %}
 </div>

--- a/templates/myuploads.html
+++ b/templates/myuploads.html
@@ -1,21 +1,20 @@
-{% extends 'base-deprecated.html' %}
+{% extends 'base.html' %}
 {% load static %}
 {% load upToCharacter %}
 {% block content %}
 
-<h3>{{user.username | upToCharacter:"@"}}'s Uploads</h3>
+<h3 class="mb-3">Your uploads</h3>
 
-<h4>Need to correct an error?</h4>
-<p>Please email <a href="mailto:syllabishare@gmail.com?subject=Error%20in%20syllabus">syllabishare@gmail.com</a> or <a href='https://github.com/SyllabiShare/syllabi-share/issues'>open a pull request on GitHub</a>.</p>
-
-<h4>Your {{posts.count}} uploaded syllab{{posts.count|pluralize:"us,i"}} for the {{school}}</h3>
+<div class="callout callout-warning">
+  <b>Need to correct an error?</b>
+  <p class="mb-0">Please email <a href="mailto:syllabishare@gmail.com?subject=Error%20in%20syllabus">syllabishare@gmail.com</a> or <a href='https://github.com/SyllabiShare/syllabi-share/issues'>open a pull request on GitHub</a>.</p>
+</div>
 
 <div class="d-flex flex-wrap">
   {% for post in posts %}
-  <div class="card">
-      <h5 class="card-title card-header">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</h5>
+  <div class="card bg-light">
+      <h5 class="card-title card-header"><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</a></h5>
       <ul class="list-group list-group-flush">
-        <li class="list-group-item"><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" class="btn btn-success" target="_blank">Syllabus <span class="sr-only">for {{ post.dept }} {{ post.number }} taught by {{post.prof}}</span></a></li>
         <li class="list-group-item"><strong>Course title:</strong> {{post.title}}</li>
         <li class="list-group-item"><strong>Semester:</strong> {{post.semester|capfirst}} {{post.year}}</li>
         <li class="list-group-item">

--- a/templates/myuploads.html
+++ b/templates/myuploads.html
@@ -3,7 +3,12 @@
 {% load upToCharacter %}
 {% block content %}
 
-<h3>{{user.username | upToCharacter:"@"}}'s {{posts.count}} uploaded syllab{{posts.count|pluralize:"us,i"}} for the {{school}}</h3>
+<h3>{{user.username | upToCharacter:"@"}}'s Uploads</h3>
+
+<h4>Need to correct an error?</h4>
+<p>Please email <a href="mailto:syllabishare@gmail.com?subject=Error%20in%20syllabus">syllabishare@gmail.com</a> or <a href='https://github.com/SyllabiShare/syllabi-share/issues'>open a pull request on GitHub</a>.</p>
+
+<h4>Your {{posts.count}} uploaded syllab{{posts.count|pluralize:"us,i"}} for the {{school}}</h3>
 
 <div class="d-flex flex-wrap">
   {% for post in posts %}
@@ -23,8 +28,5 @@
   </div>
   {% endfor %}
 </div>
-
-<h4>Need to correct an error?</h4>
-<p>Please email <a href="mailto:syllabishare@gmail.com?subject=Error%20in%20syllabus">syllabishare@gmail.com</a> or <a href='https://github.com/SyllabiShare/syllabi-share/issues'>open a pull request on GitHub</a>.</p>
 
 {% endblock %}

--- a/templates/myuploads.html
+++ b/templates/myuploads.html
@@ -12,19 +12,19 @@
 
 <div class="d-flex flex-wrap">
   {% for post in posts %}
-  <div class="syllabus">
-    <strong>{{ post.dept }} {{ post.number }} taught by {{post.prof}}</strong>
-    <ul>
-        <li><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" class="btn btn-success" target="_blank">Syllabus <span class="sr-only">for {{ post.dept }} {{ post.number }} taught by {{post.prof}}</span></a></li>
-        <li><strong>Course title:</strong> {{post.title}}</li>
-        <li><strong>Semester:</strong> {{post.semester|capfirst}} {{post.year}}</li>
-        <li>
+  <div class="card">
+      <h5 class="card-title card-header">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</h5>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item"><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" class="btn btn-success" target="_blank">Syllabus <span class="sr-only">for {{ post.dept }} {{ post.number }} taught by {{post.prof}}</span></a></li>
+        <li class="list-group-item"><strong>Course title:</strong> {{post.title}}</li>
+        <li class="list-group-item"><strong>Semester:</strong> {{post.semester|capfirst}} {{post.year}}</li>
+        <li class="list-group-item">
             <strong>Approved and visible?</strong>
             {% if post.hidden %} No
             {% else %} Yes
             {% endif %}
         </li>
-    </ul>
+      </ul>
   </div>
   {% endfor %}
 </div>

--- a/templates/myuploads.html
+++ b/templates/myuploads.html
@@ -1,0 +1,26 @@
+{% extends 'base-deprecated.html' %}
+{% load static %}
+{% load upToCharacter %}
+{% block content %}
+
+<h3>{{user.username | upToCharacter:"@"}}'s {{posts.count}} Uploaded Syllab{{posts.count|pluralize:"us,i"}} for the {{school}}</h3>
+
+<div class="text-center">
+  {% for post in posts %}
+  <div class="syllabus">
+    <ul>
+        <li><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" class="btn btn-success" target="_blank">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</a></li>
+        <li>Course title: {{post.title}}</li>
+        <li>Semester: {{post.semester}} {{post.year}}</li>
+        <li>
+            Status:
+            {% if post.hidden %} We have not received approval to show this syllabus.
+            {% else %} Approval received! This syllabus should now be visible to all.
+            {% endif %}
+        </li>
+    </ul>
+  </div>
+  {% endfor %}
+</div>
+
+{% endblock %}

--- a/templates/myuploads.html
+++ b/templates/myuploads.html
@@ -7,7 +7,7 @@
 
 <div class="callout callout-warning">
   <b>Need to correct an error?</b>
-  <p class="mb-0">Please email <a href="mailto:syllabishare@gmail.com?subject=Error%20in%20syllabus">syllabishare@gmail.com</a> or <a href='https://github.com/SyllabiShare/syllabi-share/issues'>open a pull request on GitHub</a>.</p>
+  <p class="mb-0">Please email <a href="mailto:syllabishare@gmail.com?subject=Error%20in%20syllabus">syllabishare@gmail.com</a> or <a href='https://github.com/SyllabiShare/syllabi-share/issues'>open an issue on GitHub</a>.</p>
 </div>
 
 <div class="d-flex flex-wrap">

--- a/templates/myuploads.html
+++ b/templates/myuploads.html
@@ -12,8 +12,8 @@
 
 <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3">
   {% for post in posts %}
-  <div class="d-flex col">
-    <div class="card my-3 flex-fill">
+  <div class="col my-3">
+    <div class="card h-100">
       <div class="card-body bg-light">
         <h5 class="card-title mb-0"><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" target="_blank">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</a></h5>
       </div>

--- a/templates/myuploads.html
+++ b/templates/myuploads.html
@@ -13,7 +13,7 @@
 <div class="d-flex flex-wrap">
   {% for post in posts %}
   <div class="card bg-light">
-      <h5 class="card-title card-header"><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</a></h5>
+      <h5 class="card-title card-header"><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" target="_blank">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</a></h5>
       <ul class="list-group list-group-flush">
         <li class="list-group-item"><strong>Course title:</strong> {{post.title}}</li>
         <li class="list-group-item"><strong>Semester:</strong> {{post.semester|capfirst}} {{post.year}}</li>

--- a/templates/myuploads.html
+++ b/templates/myuploads.html
@@ -3,24 +3,28 @@
 {% load upToCharacter %}
 {% block content %}
 
-<h3>{{user.username | upToCharacter:"@"}}'s {{posts.count}} Uploaded Syllab{{posts.count|pluralize:"us,i"}} for the {{school}}</h3>
+<h3>{{user.username | upToCharacter:"@"}}'s {{posts.count}} uploaded syllab{{posts.count|pluralize:"us,i"}} for the {{school}}</h3>
 
-<div class="text-center">
+<div class="d-flex flex-wrap">
   {% for post in posts %}
   <div class="syllabus">
+    <strong>{{ post.dept }} {{ post.number }} taught by {{post.prof}}</strong>
     <ul>
-        <li><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" class="btn btn-success" target="_blank">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</a></li>
-        <li>Course title: {{post.title}}</li>
-        <li>Semester: {{post.semester}} {{post.year}}</li>
+        <li><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" class="btn btn-success" target="_blank">Syllabus <span class="sr-only">for {{ post.dept }} {{ post.number }} taught by {{post.prof}}</span></a></li>
+        <li><strong>Course title:</strong> {{post.title}}</li>
+        <li><strong>Semester:</strong> {{post.semester|capfirst}} {{post.year}}</li>
         <li>
-            Status:
-            {% if post.hidden %} We have not received approval to show this syllabus.
-            {% else %} Approval received! This syllabus should now be visible to all.
+            <strong>Approved and visible?</strong>
+            {% if post.hidden %} No
+            {% else %} Yes
             {% endif %}
         </li>
     </ul>
   </div>
   {% endfor %}
 </div>
+
+<h4>Need to correct an error?</h4>
+<p>Please email <a href="mailto:syllabishare@gmail.com?subject=Error%20in%20syllabus">syllabishare@gmail.com</a> or <a href='https://github.com/SyllabiShare/syllabi-share/issues'>open a pull request on GitHub</a>.</p>
 
 {% endblock %}

--- a/templates/myuploads.html
+++ b/templates/myuploads.html
@@ -14,10 +14,10 @@
   {% for post in posts %}
   <div class="col my-3">
     <div class="card h-100">
-      <div class="card-body bg-light">
+      <div class="card-body bg-light flex-grow-0">
         <h5 class="card-title mb-0"><a href="https://{{AWS_S3_CUSTOM_DOMAIN}}/{{post.syllabus}}" target="_blank">{{ post.dept }} {{ post.number }} taught by {{post.prof}}</a></h5>
       </div>
-      <ul class="list-unstyled pl-4 mt-2">
+      <ul class="list-unstyled px-4 mt-2 flex-grow-1">
         <li><strong>Course title:</strong> {{post.title}}</li>
         <li><strong>Semester:</strong> {{post.semester|capfirst}} {{post.year}}</li>
         <li>

--- a/templates/navbar-logged-in.html
+++ b/templates/navbar-logged-in.html
@@ -49,7 +49,8 @@
           {{user.username | upToCharacter:"@"}}
         </a>
         <div class="dropdown-menu dropdown-menu-right" style="min-width: 0;">
-            <a class="dropdown-item" href="/settings">Settings</a>
+          <a class="dropdown-item" href="/myuploads">My Uploads</a>
+          <a class="dropdown-item" href="/settings">Settings</a>
             <a class="dropdown-item" href="{% url 'logout' %}">Logout</a>
         </div>
       </li>

--- a/templates/suggest.html
+++ b/templates/suggest.html
@@ -9,9 +9,9 @@
     <label for="suggestion">Suggestion</label>
     <textarea class="form-control" id="suggestion" name="suggestion" required></textarea>
   </div>
-  <p class="mb-0">Consider opening a GitHub issue for me to triage <a href='https://github.com/SyllabiShare/syllabi-share/issues'>here</a></p>
+  <p class="mb-0">You may want to <a href='https://github.com/SyllabiShare/syllabi-share/issues'>open a GitHub issue</a> for me to triage </a></p>
   <div class="form-group">
-    <label for="githubLink">Issue (optional)</label>
+    <label for="githubLink">Link to GitHub issue (optional)</label>
     <input class="form-control" id="githubLink" type="text" name="githubLink">
   </div>
   <input class="btn btn-success" type="submit" value="Submit">


### PR DESCRIPTION
This page displays all the details we have about the user's uploaded syllabi. Also added to the top navigation (not pictured).

Not sure about terminology. "My Uploads"? "Your Uploads"? "{{user.username}}'s Uploads"?

Not sure about the location of "Need to correct an error?" I think the location makes logical sense, but it's not readily visible for anyone who uploads a whole bunch of syllabi or people on mobile. I would move it to the top, except it would be weird for the syllabi to be under the "Need to correct an error?" heading and having "Your uploads" so close to the page's "{{user.username}}'s uploaded syllabi" heading feels redundant. Hmm...

Also, I can make things functionally aesthetic (e.g. focus styles!) but I have no idea how to make things Aesthetic^TM. Hahaha

![screenshot with large screen; the uploaded syllabi are in 2 rows of 3 syllabi each](https://user-images.githubusercontent.com/26099970/87090884-b629b380-c206-11ea-93c3-dd98986ef8a3.png)
![partial screenshot with small or medium screen; the uploaded syllabi each have their own row](https://user-images.githubusercontent.com/26099970/87090888-b9bd3a80-c206-11ea-8b04-f3877be4eecb.png)
