### PR TITLE
Improving breadcrumbs

### DIFF
--- a/project/static/style.css
+++ b/project/static/style.css
@@ -41,6 +41,12 @@
     color: black;
 }
 
+/* own classes for breadcrumbs; default is showing breadcrumbs below, not in the top navbar; toggle display with media query */
+.breadcrumbs-within {
+    display: none;
+}
+
+
 /*** FOOTER ***/
 
 footer {
@@ -162,4 +168,21 @@ body {
 .auth-form {
     width: 400px;
     max-width: 100%;
+}
+
+/* for easy ref, Bootstrap's breakpoints
+ * sm - min-width: 576px
+ * md - min-width: 768px
+ * lg - min-width: 992px
+ * xl - min-width: 1200px
+ * should use Sass mixins when we get Sass in:
+ * https://getbootstrap.com/docs/4.5/layout/overview/#responsive-breakpoints
+*/
+@media only screen and (min-width: 1200px) {
+    .breadcrumbs-within {
+        display: inline-block;
+    }
+    .breadcrumbs-below {
+        display: none;
+    }
 }

--- a/syllabiShare/views.py
+++ b/syllabiShare/views.py
@@ -121,7 +121,7 @@ def send_confirmation_email(user, request):
 
 
 def about(request):
-    return render(request, 'about.html', {'breadcrumb': 'About'})
+    return render(request, 'about.html')
 
 
 @login_required
@@ -304,7 +304,7 @@ def upload(request):
         else:
             messages.error(request, 'Please enter the professor\'s name as "FirstName LastName"')
         return redirect("syllabiShare:upload")  # prevents re-post on refresh problem
-    return render(request, 'upload.html', {'breadcrumb': 'Upload'})
+    return render(request, 'upload.html')
 
 
 def view404(request, exception=None):

--- a/templates/breadcrumbs.html
+++ b/templates/breadcrumbs.html
@@ -1,0 +1,18 @@
+<nav aria-label="breadcrumb" >
+    <ol class="breadcrumb" style="margin: auto;">
+      <li class="breadcrumb-item"><a href="/">{{ user.profile.school.name }}</a></li>
+      {% if not index %}
+      <li class="breadcrumb-item active" aria-current="page"><!--
+     -->{% if search_string %}<!-- workaround for those extra spaces
+     -->Search results for "{{search_string}}"<!--
+     -->{% elif dept %}<!--
+     -->{{ dept }}<!--
+     -->{% elif breadcrumb %}<!--
+     -->{{ breadcrumb }}<!--
+     -->{% else %}<!--
+     -->{{ request.resolver_match.url_name|capfirst }}<!--
+     -->{% endif %}<!--
+   --></li>
+      {% endif %}
+    </ol>
+</nav>

--- a/templates/navbar-logged-in.html
+++ b/templates/navbar-logged-in.html
@@ -5,23 +5,9 @@
     <span class="navbar-toggler-icon"></span>
   </button>
 
+  <div class="breadcrumbs-within">{% include 'breadcrumbs.html' %}</div>
+
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <nav aria-label="breadcrumb" >
-      <ol class="breadcrumb" style="margin: auto;">
-        <li class="breadcrumb-item"><a href="/">{{ user.profile.school.name }}</a></li>
-        {% if not index %}
-        <li class="breadcrumb-item active" aria-current="page"><!--
-       -->{% if search_string %}<!-- workaround for those extra spaces
-       -->Search results for "{{search_string}}"<!--
-       -->{% elif dept %}<!--
-       -->{{ dept }}<!--
-       -->{% else %}<!--
-       -->{{ breadcrumb }}<!--
-       -->{% endif %}<!--
-     --></li>
-        {% endif %}
-      </ol>
-    </nav>
     <ul class="navbar-nav ml-auto d-flex align-items-lg-center">
       <li class="nav-item">
         {# mt-2, mt-lg-0: provide a top margin when we're collapsed but not when expanded #}
@@ -56,3 +42,5 @@
     </ul>
   </div>
 </nav>
+
+<div class="breadcrumbs-below container my-3">{% include 'breadcrumbs.html' %}</div>


### PR DESCRIPTION
there is exactly 1 commit in this branch and it reads as follows:

> moving breadcrumbs out of the top navbar unless your screen is enormous... a little brute force, hopefully not too bad; also removed the need to specify the more straightforward breadcrumbs in context

not planning on doing anything further unless there's a way to detect when the breadcrumbs are really long (might happen for search strings) and toggle the `display` attribute then, but even then I don't think I'd want to make that happen since then the breadcrumb location would be inconsistent for the same screen size